### PR TITLE
Add option to selectively emit events when entries are put or deleted

### DIFF
--- a/CacheEntry.js
+++ b/CacheEntry.js
@@ -8,6 +8,14 @@ class CacheEntry {
     this.ttl = ttl;
     this.expiresTimestamp = (ttl === -1) ? undefined : (Date.now() + ttl);
     this.keepAliveOnAccess = (options.keepAliveOnAccess !== false);
+
+    // apply cache options value as default if entry option is
+    // null or undefined
+    if (options.emitKeyChanges === undefined || options.emitKeyChanges === null) {
+      this.emitKeyChanges = cache._emitKeyChanges;
+    } else {
+      this.emitKeyChanges = !!options.emitKeyChanges;
+    }
   }
 }
 

--- a/CacheEntry.js
+++ b/CacheEntry.js
@@ -11,10 +11,10 @@ class CacheEntry {
 
     // apply cache options value as default if entry option is
     // null or undefined
-    if (options.emitKeyChanges === undefined || options.emitKeyChanges === null) {
-      this.emitKeyChanges = cache._emitKeyChanges;
+    if (options.emitEntryChanges === undefined || options.emitEntryChanges === null) {
+      this.emitEntryChanges = cache._emitEntryChanges;
     } else {
-      this.emitKeyChanges = !!options.emitKeyChanges;
+      this.emitEntryChanges = !!options.emitEntryChanges;
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ let value = cache.get(myKey); // 'world'
 ```
 
 The cache will emit an event when cache entries are put and deleted if
-the `emitKeyChanges` option is set;
+the `emitEntryChanges` option is set;
 
 ```js
-const cache = InMemoryCache.create({ emitKeyChanges: true });
+const cache = InMemoryCache.create({ emitEntryChanges: true });
 
 cache.on(`put:${myKey}`, (data) => {
   // data === the entryData that was initially inserted
@@ -51,7 +51,7 @@ cache.on(`delete:${myKey}`, (data) => {
   // data === the entryData that was initially inserted
 });
 
-cache.put(myKey, myData, { emitKeyChanges: true }); // triggers the put listener
+cache.put(myKey, myData, { emitEntryChanges: true }); // triggers the put listener
 cache.delete(myKey); // triggers the delete listener
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,3 +19,41 @@ const myKey = 'hello';
 cache.put(myKey, 'world');
 let value = cache.get(myKey); // 'world'
 ```
+
+The cache will emit an event when cache entries are put and deleted if
+the `emitKeyChanges` option is set;
+
+```js
+const cache = InMemoryCache.create({ emitKeyChanges: true });
+
+cache.on(`put:${myKey}`, (data) => {
+  // data === the entryData that was initially inserted
+});
+
+cache.on(`delete:${myKey}`, (data) => {
+  // data === the entryData that was initially inserted
+});
+
+cache.put(myKey, myData); // triggers the put listener
+cache.delete(myKey); // triggers the delete listener
+```
+
+Alternatively, the option can also be set as an option when values are being set.
+
+```js
+const cache = InMemoryCache.create();
+
+cache.on(`put:${myKey}`, (data) => {
+  // data === the entryData that was initially inserted
+});
+
+cache.on(`delete:${myKey}`, (data) => {
+  // data === the entryData that was initially inserted
+});
+
+cache.put(myKey, myData, { emitKeyChanges: true }); // triggers the put listener
+cache.delete(myKey); // triggers the delete listener
+```
+
+Note: Setting the option on the entry will override the default cache option. This allows for
+finer control over what entries the cache will (or will not) emit events for.

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ class InMemoryCache extends EventEmitter {
     this._ttlDefault = options.ttlDefault;
     this._entries = Object.create(null);
     this._reaperTimerId = null;
-    this._emitKeyChanges = !!options.emitKeyChanges;
+    this._emitEntryChanges = !!options.emitEntryChanges;
   }
 
   put (cacheKey, data, options) {
@@ -25,7 +25,7 @@ class InMemoryCache extends EventEmitter {
 
     this._entries[cacheKey] = cacheEntry;
 
-    if (cacheEntry.emitKeyChanges) {
+    if (cacheEntry.emitEntryChanges) {
       this.emit(`put:${cacheKey}`, data);
     }
   }
@@ -35,7 +35,7 @@ class InMemoryCache extends EventEmitter {
 
     delete this._entries[cacheKey];
 
-    if (entry.emitKeyChanges) {
+    if (entry.emitEntryChanges) {
       this.emit(`delete:${cacheKey}`, entry.data);
     }
   }

--- a/index.js
+++ b/index.js
@@ -2,15 +2,18 @@
 
 const CacheEntry = require('./CacheEntry');
 const conflogger = require('conflogger');
+const { EventEmitter } = require('events');
 
-class InMemoryCache {
+class InMemoryCache extends EventEmitter {
   constructor (options) {
+    super();
     options = options || {};
 
     this._logger = conflogger.configure(options.logger);
     this._ttlDefault = options.ttlDefault;
     this._entries = Object.create(null);
     this._reaperTimerId = null;
+    this._emitKeyChanges = !!options.emitKeyChanges;
   }
 
   put (cacheKey, data, options) {
@@ -21,10 +24,20 @@ class InMemoryCache {
     }
 
     this._entries[cacheKey] = cacheEntry;
+
+    if (cacheEntry.emitKeyChanges) {
+      this.emit(`put:${cacheKey}`, data);
+    }
   }
 
   delete (cacheKey) {
+    let entry = this._entries[cacheKey];
+
     delete this._entries[cacheKey];
+
+    if (entry.emitKeyChanges) {
+      this.emit(`delete:${cacheKey}`, entry.data);
+    }
   }
 
   getEntry (cacheKey) {
@@ -82,7 +95,8 @@ class InMemoryCache {
         if (this._logger.isDebugEnabled()) {
           this._logger.debug(`Removing expired entry ${cacheKey}`);
         }
-        delete entries[cacheKey];
+
+        this.delete(cacheKey);
       }
     }
   }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -2,6 +2,7 @@
   "globals": {
       "it": 1,
       "describe": 1,
+      "context": 1,
       "beforeEach": 1,
       "afterEach": 1
     }

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,67 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const InMemoryCache = require('../');
+const EMIT_KEY_CHANGES_ENABLED = { emitKeyChanges: true };
+const EMIT_KEY_CHANGES_DISABLED = { emitKeyChanges: false };
+
+function _putEntryEventTest (cache, entryOptions, expectedResult) {
+  const cacheKey = 'abc';
+  const entryData = 123;
+
+  let putEventEmitted = false;
+
+  cache.on(`put:${cacheKey}`, (data) => {
+    if (entryData === data) {
+      putEventEmitted = true;
+    }
+  });
+
+  cache.put(cacheKey, entryData, entryOptions);
+  expect(putEventEmitted).to.equal(expectedResult);
+}
+
+function _deleteEntryEventTest (cache, entryOptions, expectedResult) {
+  const cacheKey = 'abc';
+  const entryData = 123;
+
+  let deleteEventEmitted = false;
+
+  cache.put(cacheKey, entryData, entryOptions);
+
+  cache.on(`delete:${cacheKey}`, (data) => {
+    if (entryData === data) {
+      deleteEventEmitted = true;
+    }
+  });
+
+  cache.delete(cacheKey);
+  expect(cache.get(cacheKey)).to.equal(undefined);
+  expect(deleteEventEmitted).to.equal(expectedResult);
+}
+
+function _reapEntryEventTest (cache, entryOptions, expectedResult, done) {
+  const cacheKey = 'abc';
+  const entryData = 123;
+
+  let entryRemoved = false;
+
+  let options = Object.assign(entryOptions || {}, { ttl: 100 });
+  cache.put(cacheKey, entryData, options);
+
+  cache.on(`delete:${cacheKey}`, (data) => {
+    if (entryData === data) {
+      entryRemoved = true;
+    }
+  });
+
+  cache.startReaper(200);
+
+  setTimeout(() => {
+    expect(cache.get(cacheKey)).to.equal(undefined);
+    expect(entryRemoved).to.equal(expectedResult);
+    done();
+  }, 400);
+}
 
 describe('InMemoryCache', function () {
   let cache;
@@ -24,7 +85,6 @@ describe('InMemoryCache', function () {
   });
 
   it('should allow cache entry with no TTL', () => {
-    const cache = InMemoryCache.create();
     const cacheKey = 'abc';
 
     cache.put(cacheKey, 123, {
@@ -44,7 +104,6 @@ describe('InMemoryCache', function () {
   });
 
   it('should remove expired entry using manual reaping', (done) => {
-    const cache = InMemoryCache.create();
     const cacheKey = 'abc';
 
     cache.put(cacheKey, 123, {
@@ -73,5 +132,167 @@ describe('InMemoryCache', function () {
       expect(cache.get(cacheKey)).to.equal(undefined);
       done();
     }, 400);
+  });
+
+  context('"emitKeyChanges" cache option is not set (default), entry option is not set', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create();
+    });
+
+    it('should NOT emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, undefined, false);
+    });
+
+    it('should NOT emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, undefined, false);
+    });
+
+    it('should NOT emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, undefined, false, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is not set, entry option is set to "true"', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create();
+    });
+
+    it('should emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+    });
+
+    it('should emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+    });
+
+    it('should emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is not set, entry option is set to "false"', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create();
+    });
+
+    it('should emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+    });
+
+    it('should emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+    });
+
+    it('should emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is set to "true", entry option is not set', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create(EMIT_KEY_CHANGES_ENABLED);
+    });
+
+    it('should emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, undefined, true);
+    });
+
+    it('should emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, undefined, true);
+    });
+
+    it('should emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, undefined, true, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is set to "true", entry option is set to "true"', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create(EMIT_KEY_CHANGES_ENABLED);
+    });
+
+    it('should emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+    });
+
+    it('should emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+    });
+
+    it('should emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is set to "true", entry option is set to "false"', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create(EMIT_KEY_CHANGES_ENABLED);
+    });
+
+    it('should override cache option and NOT emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+    });
+
+    it('should override cache option and NOT emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+    });
+
+    it('should override cache option and NOT emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is set to "false", entry option is not set', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create(EMIT_KEY_CHANGES_DISABLED);
+    });
+
+    it('should NOT emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, undefined, false);
+    });
+
+    it('should NOT emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, undefined, false);
+    });
+
+    it('should NOT emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, undefined, false, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is set to "false", entry option is set to "true"', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create(EMIT_KEY_CHANGES_DISABLED);
+    });
+
+    it('should override cache option and emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+    });
+
+    it('should override cache option and emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+    });
+
+    it('should override cache option and emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true, done);
+    });
+  });
+
+  context('"emitKeyChanges" cache option is set to "false", entry option is set to "false"', () => {
+    beforeEach(() => {
+      cache = InMemoryCache.create(EMIT_KEY_CHANGES_DISABLED);
+    });
+
+    it('should NOT emit an event when an entry is added', () => {
+      _putEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+    });
+
+    it('should NOT emit an event when an entry is deleted', () => {
+      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+    });
+
+    it('should NOT emit an event when an entry is reaped', (done) => {
+      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false, done);
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -2,8 +2,8 @@ const chai = require('chai');
 const expect = chai.expect;
 
 const InMemoryCache = require('../');
-const EMIT_KEY_CHANGES_ENABLED = { emitKeyChanges: true };
-const EMIT_KEY_CHANGES_DISABLED = { emitKeyChanges: false };
+const EMIT_ENTRY_CHANGES_ENABLED = { emitEntryChanges: true };
+const EMIT_ENTRY_CHANGES_DISABLED = { emitEntryChanges: false };
 
 function _putEntryEventTest (cache, entryOptions, expectedResult) {
   const cacheKey = 'abc';
@@ -134,11 +134,7 @@ describe('InMemoryCache', function () {
     }, 400);
   });
 
-  context('"emitKeyChanges" cache option is not set (default), entry option is not set', () => {
-    beforeEach(() => {
-      cache = InMemoryCache.create();
-    });
-
+  context('"emitEntryChanges" cache option is not set (default), entry option is not set', () => {
     it('should NOT emit an event when an entry is added', () => {
       _putEntryEventTest(cache, undefined, false);
     });
@@ -152,45 +148,37 @@ describe('InMemoryCache', function () {
     });
   });
 
-  context('"emitKeyChanges" cache option is not set, entry option is set to "true"', () => {
-    beforeEach(() => {
-      cache = InMemoryCache.create();
-    });
-
+  context('"emitEntryChanges" cache option is not set, entry option is set to "true"', () => {
     it('should emit an event when an entry is added', () => {
-      _putEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+      _putEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true);
     });
 
     it('should emit an event when an entry is deleted', () => {
-      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+      _deleteEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true);
     });
 
     it('should emit an event when an entry is reaped', (done) => {
-      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true, done);
+      _reapEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true, done);
     });
   });
 
-  context('"emitKeyChanges" cache option is not set, entry option is set to "false"', () => {
-    beforeEach(() => {
-      cache = InMemoryCache.create();
-    });
-
+  context('"emitEntryChanges" cache option is not set, entry option is set to "false"', () => {
     it('should emit an event when an entry is added', () => {
-      _putEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+      _putEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false);
     });
 
     it('should emit an event when an entry is deleted', () => {
-      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+      _deleteEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false);
     });
 
     it('should emit an event when an entry is reaped', (done) => {
-      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false, done);
+      _reapEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false, done);
     });
   });
 
-  context('"emitKeyChanges" cache option is set to "true", entry option is not set', () => {
+  context('"emitEntryChanges" cache option is set to "true", entry option is not set', () => {
     beforeEach(() => {
-      cache = InMemoryCache.create(EMIT_KEY_CHANGES_ENABLED);
+      cache = InMemoryCache.create(EMIT_ENTRY_CHANGES_ENABLED);
     });
 
     it('should emit an event when an entry is added', () => {
@@ -206,45 +194,45 @@ describe('InMemoryCache', function () {
     });
   });
 
-  context('"emitKeyChanges" cache option is set to "true", entry option is set to "true"', () => {
+  context('"emitEntryChanges" cache option is set to "true", entry option is set to "true"', () => {
     beforeEach(() => {
-      cache = InMemoryCache.create(EMIT_KEY_CHANGES_ENABLED);
+      cache = InMemoryCache.create(EMIT_ENTRY_CHANGES_ENABLED);
     });
 
     it('should emit an event when an entry is added', () => {
-      _putEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+      _putEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true);
     });
 
     it('should emit an event when an entry is deleted', () => {
-      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+      _deleteEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true);
     });
 
     it('should emit an event when an entry is reaped', (done) => {
-      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true, done);
+      _reapEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true, done);
     });
   });
 
-  context('"emitKeyChanges" cache option is set to "true", entry option is set to "false"', () => {
+  context('"emitEntryChanges" cache option is set to "true", entry option is set to "false"', () => {
     beforeEach(() => {
-      cache = InMemoryCache.create(EMIT_KEY_CHANGES_ENABLED);
+      cache = InMemoryCache.create(EMIT_ENTRY_CHANGES_ENABLED);
     });
 
     it('should override cache option and NOT emit an event when an entry is added', () => {
-      _putEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+      _putEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false);
     });
 
     it('should override cache option and NOT emit an event when an entry is deleted', () => {
-      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+      _deleteEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false);
     });
 
     it('should override cache option and NOT emit an event when an entry is reaped', (done) => {
-      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false, done);
+      _reapEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false, done);
     });
   });
 
-  context('"emitKeyChanges" cache option is set to "false", entry option is not set', () => {
+  context('"emitEntryChanges" cache option is set to "false", entry option is not set', () => {
     beforeEach(() => {
-      cache = InMemoryCache.create(EMIT_KEY_CHANGES_DISABLED);
+      cache = InMemoryCache.create(EMIT_ENTRY_CHANGES_DISABLED);
     });
 
     it('should NOT emit an event when an entry is added', () => {
@@ -260,39 +248,39 @@ describe('InMemoryCache', function () {
     });
   });
 
-  context('"emitKeyChanges" cache option is set to "false", entry option is set to "true"', () => {
+  context('"emitEntryChanges" cache option is set to "false", entry option is set to "true"', () => {
     beforeEach(() => {
-      cache = InMemoryCache.create(EMIT_KEY_CHANGES_DISABLED);
+      cache = InMemoryCache.create(EMIT_ENTRY_CHANGES_DISABLED);
     });
 
     it('should override cache option and emit an event when an entry is added', () => {
-      _putEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+      _putEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true);
     });
 
     it('should override cache option and emit an event when an entry is deleted', () => {
-      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true);
+      _deleteEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true);
     });
 
     it('should override cache option and emit an event when an entry is reaped', (done) => {
-      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_ENABLED, true, done);
+      _reapEntryEventTest(cache, EMIT_ENTRY_CHANGES_ENABLED, true, done);
     });
   });
 
-  context('"emitKeyChanges" cache option is set to "false", entry option is set to "false"', () => {
+  context('"emitEntryChanges" cache option is set to "false", entry option is set to "false"', () => {
     beforeEach(() => {
-      cache = InMemoryCache.create(EMIT_KEY_CHANGES_DISABLED);
+      cache = InMemoryCache.create(EMIT_ENTRY_CHANGES_DISABLED);
     });
 
     it('should NOT emit an event when an entry is added', () => {
-      _putEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+      _putEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false);
     });
 
     it('should NOT emit an event when an entry is deleted', () => {
-      _deleteEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false);
+      _deleteEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false);
     });
 
     it('should NOT emit an event when an entry is reaped', (done) => {
-      _reapEntryEventTest(cache, EMIT_KEY_CHANGES_DISABLED, false, done);
+      _reapEntryEventTest(cache, EMIT_ENTRY_CHANGES_DISABLED, false, done);
     });
   });
 });


### PR DESCRIPTION
This change allows for listeners to be added to the cache for when an entry is added or deleted. Great for debugging.